### PR TITLE
Fixed typo in testing instructions found while trying the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Basic calendar application using CSS and HTML with minimal jquery.
 Open index.html in the browser. Within the browser console, you can run 
 
 ```
-layoutDay(events);
+layOutDay(events);
 ```
 
 to display your daily schedule. You can define the calendar in your console first using the format


### PR DESCRIPTION
A function name was capitalized differently in the readme vs. the implementation